### PR TITLE
colby::conversions.hpp: Roll our own Lab conversions

### DIFF
--- a/include/colby/conversions.hpp
+++ b/include/colby/conversions.hpp
@@ -1,0 +1,195 @@
+/**
+ *	\file
+ */
+
+#pragma once
+
+#include <opencv2/core/mat.hpp>
+#include <opencv2/core/matx.hpp>
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+namespace colby {
+
+/**
+ *	Converts a 32-bit floating point XYZ value to a 32-bit floating point value in CIELAB.
+ *
+ *	\param [in] lab
+ *		The color in XYZ
+ *	\returns
+ *		The color in CIELAB
+ */
+inline cv::Vec3f xyz2lab(const cv::Vec3f xyz) noexcept {
+	auto x = xyz[0]/95.047f;
+	auto y = xyz[1]/100.f;
+	auto z = xyz[2]/108.883f;
+
+	x = x > 0.008856f ? std::pow(x, 1.f/3.f) : 7.787f*x+16.f/116.f;
+	y = y > 0.008856f ? std::pow(y, 1.f/3.f) : 7.787f*y+16.f/116.f;
+	z = z > 0.008856f ? std::pow(z, 1.f/3.f) : 7.787f*z+16.f/116.f;
+
+	auto l = 116.f*y-16.f;
+	auto a = 500.f*(x-y);
+	auto b = 200.f*(y-z);
+
+	return cv::Vec3f(l,a,b);
+}
+
+/**
+ *	Converts a 32-bit floating point CIELAB value to a 32-bit floating point value in XYZ.
+ *
+ *	\param [in] lab
+ *		The color in CIELAB
+ *	\returns
+ *		The color in XYZ
+ */
+inline cv::Vec3f lab2xyz(const cv::Vec3f lab) noexcept {
+	auto l = lab[0];
+	auto a = lab[1];
+	auto b = lab[2];
+
+	auto y = (l+16.f)/116.f;
+	auto x = a/500.f+y;
+	auto z = y-b/200.f;
+
+	x = std::pow(x, 3.f)>0.008856f ? std::pow(x, 3.f)  : (x-16.f/116.f)/7.787f;
+	y = std::pow(y, 3.f)>0.008856f ? std::pow(y, 3.f)  : (y-16.f/116.f)/7.787f;
+	z = std::pow(z, 3.f)>0.008856f ? std::pow(z, 3.f)  : (z-16.f/116.f)/7.787f;
+
+	x *= 95.047f;
+	y *= 100.f;
+	z *= 108.883f;
+
+	return cv::Vec3f(x,y,z);
+}
+
+/**
+ *	Converts an 8-bit BGR value to a 32-bit floating point value in XYZ.
+ *
+ *	\param [in] bgr
+ *		The color in BGR
+ *	\returns
+ *		The color in XYZ
+ */
+inline cv::Vec3f bgr2xyz(const cv::Vec3b bgr) noexcept {
+	auto r = bgr[2]/255.f;
+	auto g = bgr[1]/255.f;
+	auto b = bgr[0]/255.f;
+
+	r = r>0.04045f ? std::pow(((r+0.055f)/1.055f), 2.4f) : r/12.92f;
+	g = g>0.04045f ? std::pow(((g+0.055f)/1.055f), 2.4f) : g/12.92f;
+	b = b>0.04045f ? std::pow(((b+0.055f)/1.055f), 2.4f) : b/12.92f;
+
+	r *= 100.f;
+	g *= 100.f;
+	b *= 100.f;
+
+	auto x = r*0.4124f+g*0.3576f+b*0.1805f;
+	auto y = r*0.2126f+g*0.7152f+b*0.0722f;
+	auto z = r*0.0193f+g*0.1192f+b*0.9505f;
+
+	return cv::Vec3f(x,y,z);
+}
+
+/**
+ *	Converts a 32-bit floating point XYZ value to an 8-bit BGR value.
+ *
+ *	\param [in] xyz
+ *		The color in XYZ
+ *	\returns
+ *		The color in BGR
+ */
+inline cv::Vec3b xyz2bgr(const cv::Vec3f xyz) noexcept {
+	auto x = xyz[0]/100.f;
+	auto y = xyz[1]/100.f;
+	auto z = xyz[2]/100.f;
+
+	auto r = x*3.2406f+y*-1.5372f+z*-0.4986f;
+	auto g = x*-0.9689f+y*1.8758f+z*0.0415f;
+	auto b = x*0.0557f+y*-0.2040f+z*1.0570f;
+
+	r = r > 0.0031308f ? 1.055f*std::pow(r, 1.f/2.4f)-0.055f : 12.92f*r;
+	g = g > 0.0031308f ? 1.055f*std::pow(g, 1.f/2.4f)-0.055f : 12.92f*g;
+	b = b > 0.0031308f ? 1.055f*std::pow(b, 1.f/2.4f)-0.055f : 12.92f*b;
+
+	r *= 255.f;
+	g *= 255.f;
+	b *= 255.f;
+
+	if (r < 0) r = 0;
+	if (g < 0) g = 0;
+	if (b < 0) b = 0;
+
+	if (r > 255.f) r = 255.f;
+	if (g > 255.f) g = 255.f;
+	if (b > 255.f) b = 255.f;
+
+	return cv::Vec3b(b,g,r);
+}
+
+/**
+ *	Converts a 8-bit BGR value to 32-bit floating
+ *	point CIELAB value.
+ *
+ *	\param [in] bgr
+ *		The color in BGR
+ *	\returns
+ *		The color in CIELAB space
+ */
+inline cv::Vec3f bgr2lab (const cv::Vec3b bgr) noexcept {
+	return xyz2lab(bgr2xyz(bgr));
+}
+
+/**
+ *	Converts a 32-bit floating point CIELAB value
+ *	to an 8-bit BGR value
+ *
+ *	\param [in] lab
+ *		The color in CIELAB space
+ *	\returns
+ *		The color in BGR
+ */
+inline cv::Vec3b lab2bgr (const cv::Vec3f lab) noexcept {
+	return xyz2bgr(lab2xyz(lab));
+}
+
+/**
+ *	Converts a cv::Mat of 8-bit BGR values to 32-bit floating
+ *	point CIELAB values.
+ *
+ *	\param [in] bgr
+ *		A cv::Mat of BGR values
+ *	\returns
+ *		A cv::Mat of CIELAB values
+ */
+inline cv::Mat bgr2lab(const cv::Mat & bgr) {
+	if (bgr.type() != CV_8UC3) throw std::logic_error("Expected 3 channel 8 bit image");
+	cv::Mat retr(bgr.rows, bgr.cols, CV_32FC3);
+	auto out = reinterpret_cast<cv::Vec3f *>(retr.data);
+	auto begin = reinterpret_cast<const cv::Vec3b *>(bgr.data);
+	auto end = begin + (bgr.rows * bgr.cols);
+	std::transform(begin,end,out,[] (auto && v) noexcept {	return bgr2lab(v);	});
+	return retr;
+}
+
+/**
+ *	Converts a cv::Mat of 32-bit floating point CIELAB values
+ *	to an 8-bit BGR values
+ *
+ *	\param [in] lab
+ *		A cv::Mat of colors in CIELAB space
+ *	\returns
+ *		A cv::Mat of colors in BGR space
+ */
+inline cv::Mat lab2bgr(const cv::Mat & lab) {
+	if (lab.type() != CV_32FC3) throw std::logic_error("Expected 3 channel 32 bit floating point image");
+	cv::Mat retr(lab.rows, lab.cols, CV_8UC3);
+	auto out = reinterpret_cast<cv::Vec3b *>(retr.data);
+	auto begin = reinterpret_cast<const cv::Vec3f *>(lab.data);
+	auto end = begin + (lab.rows * lab.cols);
+	std::transform(begin,end,out,[] (auto && v) noexcept {	return lab2bgr(v);	});
+	return retr;
+}
+
+}

--- a/include/colby/sp3000_color_by_numbers.hpp
+++ b/include/colby/sp3000_color_by_numbers.hpp
@@ -94,8 +94,6 @@ private:
 	std::size_t max_final_cells_;
 	std::size_t max_final_colors_;
 	sp3000_color_by_numbers_observer * o_;
-	static cv::Mat convert_bgr_to_lab (const cv::Mat &);
-	static cv::Mat convert_lab_to_bgr (const cv::Mat &);
 	static cell image_as_cell (const cv::Mat &);
 	static void subtract (cell &, const cell &);
 	std::unique_ptr<graph> divide (const cv::Mat &) const;
@@ -143,9 +141,9 @@ public:
 	sp3000_color_by_numbers (
 		std::size_t max_final_cells,
 		std::size_t max_final_colors,
-		float flood_fill_tolerance = 0.01f,
-		std::size_t small_cell_threshold = 15,
-		float similar_cell_tolerance = 0.001f
+		float flood_fill_tolerance = 10.f,
+		std::size_t small_cell_threshold = 10,
+		float similar_cell_tolerance = 5.f
 	);
 	/**
 	 *	Creates a new sp3000_color_by_numbers.
@@ -189,9 +187,9 @@ public:
 		sp3000_color_by_numbers_observer & o,
 		std::size_t max_final_cells,
 		std::size_t max_final_colors,
-		float flood_fill_tolerance = 0.01f,
-		std::size_t small_cell_threshold = 15,
-		float similar_cell_tolerance = 0.001f
+		float flood_fill_tolerance = 10.f,
+		std::size_t small_cell_threshold = 10,
+		float similar_cell_tolerance = 5.f
 	);
 	virtual result convert (const cv::Mat & src) override;
 };

--- a/src/colby/test/CMakeLists.txt
+++ b/src/colby/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(tests
 	algorithm.cpp
+	conversions.cpp
 	hash.cpp
 	main.cpp
 )

--- a/src/colby/test/conversions.cpp
+++ b/src/colby/test/conversions.cpp
@@ -1,0 +1,147 @@
+#include <colby/conversions.hpp>
+#include <opencv2/core/matx.hpp>
+#include <cmath>
+#include <catch.hpp>
+
+namespace colby {
+namespace test {
+namespace {
+
+constexpr float eps = 0.0001f;
+
+SCENARIO("colby::bgr2lab converts RGB points into Lab points","[colby][conversions][bgr2lab]") {
+
+	GIVEN("An arbitrary RGB color") {
+		cv::Vec3b bgr(145,38,45);
+		WHEN("It is converted to Lab") {
+			auto lab = bgr2lab(bgr);
+			THEN("The correct Lab color is returned") {
+				CHECK(std::abs(lab[0] - (23.6332172123127f)) < eps);
+				CHECK(std::abs(lab[1] - (37.60780721052504f)) < eps);
+				CHECK(std::abs(lab[2] - (-57.61918645116327f)) < eps);
+			}
+		}
+	}
+
+	GIVEN("The RGB color of black") {
+		cv::Vec3b bgr(0,0,0);
+		WHEN("It is converted to Lab") {
+			auto lab = bgr2lab(bgr);
+			THEN("The correct Lab color black is returned") {
+				CHECK(std::abs(lab[0] - (0.f)) < eps);
+				CHECK(std::abs(lab[1] - (0.f)) < eps);
+				CHECK(std::abs(lab[2] - (0.f)) < eps);
+			}
+		}
+	}
+
+	GIVEN("The RGB color of white") {
+		cv::Vec3b bgr(255,255,255);
+		WHEN("It is converted to Lab") {
+			auto lab = bgr2lab(bgr);
+			THEN("The correct Lab color white is returned") {
+				CHECK(std::abs(lab[0] - (100.f)) < eps);
+				CHECK(std::abs(lab[1] - (0.00526049995830391f)) < eps);
+				CHECK(std::abs(lab[2] - (-0.010408184525267927f)) < eps);
+			}
+		}
+	}
+
+	GIVEN("A cv::Mat of RGB values") {
+		cv::Mat bgr(cv::Mat::zeros(2,3,CV_8UC3));
+		bgr.at<cv::Vec3b>(0,2) = cv::Vec3b(145,38,45);
+		bgr.at<cv::Vec3b>(1,0) = cv::Vec3b(255,255,255);
+		WHEN("It is converted to Lab") {
+			auto lab = bgr2lab(bgr);
+			THEN("Each value of the cv::Mat is converted correctly") {
+
+				auto black = lab.at<cv::Vec3f>(0,0);
+				CHECK(std::abs(black[0]) < eps);
+				CHECK(std::abs(black[1]) < eps);
+				CHECK(std::abs(black[2]) < eps);
+
+				auto arbitrary = lab.at<cv::Vec3f>(0,2);
+				CHECK(std::abs(arbitrary[0] - (23.6332172123127f)) < eps);
+				CHECK(std::abs(arbitrary[1] - (37.60780721052504f)) < eps);
+				CHECK(std::abs(arbitrary[2] - (-57.61918645116327f)) < eps);
+
+				auto white = lab.at<cv::Vec3f>(1,0);
+				CHECK(std::abs(white[0] - (100.f)) < eps);
+				CHECK(std::abs(white[1] - (0.00526049995830391f)) < eps);
+				CHECK(std::abs(white[2] - (-0.010408184525267927f)) < eps);
+
+			}
+		}
+	}
+}
+
+SCENARIO("colby::lab2bgr converts Lab points into RGB points","[colby][conversions][lab2bgr]") {
+
+	GIVEN("An arbitrary Lab color") {
+		cv::Vec3f lab(34.54f,10.8f,-3.2f);
+		WHEN("It is converted to RGB") {
+			auto bgr = lab2bgr(lab);
+			THEN("The correct RGB color is returned") {
+				CHECK(std::abs(int(bgr[2]) - 96) < 2);
+				CHECK(std::abs(int(bgr[1]) - 75) < 2);
+				CHECK(std::abs(int(bgr[0]) - 87) < 2);
+			}
+		}
+	}
+
+	GIVEN("The Lab color black") {
+		cv::Vec3f lab(0.f, 0.f, 0.f);
+		WHEN("It is converted to RGB") {
+			auto bgr = lab2bgr(lab);
+			THEN("The correct RGB color is returned") {
+				CHECK(std::abs(int(bgr[2])) < 2);
+				CHECK(std::abs(int(bgr[1])) < 2);
+				CHECK(std::abs(int(bgr[0])) < 2);
+			}
+		}
+	}
+
+	GIVEN("The Lab color white") {
+		cv::Vec3f lab(100.f, 0.f, 0.f);
+		WHEN("It is converted to RGB") {
+			auto bgr = lab2bgr(lab);
+			THEN("The correct RGB color is returned") {
+				CHECK(std::abs(int(bgr[2]) - 255) < 2);
+				CHECK(std::abs(int(bgr[1]) - 255) < 2);
+				CHECK(std::abs(int(bgr[0]) - 255) < 2);
+			}
+		}
+	}
+
+	GIVEN("A cv::Mat of Lab values") {
+		cv::Mat lab(cv::Mat::zeros(2,3,CV_32FC3));
+		lab.at<cv::Vec3f>(0,2) = cv::Vec3f(34.54f,10.8f,-3.2);
+		lab.at<cv::Vec3f>(1,0) = cv::Vec3f(100.f,0.f,0.f);
+		WHEN("It is converted to Lab") {
+			auto bgr = lab2bgr(lab);
+			THEN("Each value of the cv::Mat is converted correctly") {
+
+				auto && black = bgr.at<cv::Vec3b>(0,0);
+				CHECK(std::abs(int(black[2])) < 2);
+				CHECK(std::abs(int(black[1])) < 2);
+				CHECK(std::abs(int(black[0])) < 2);
+
+				auto && arbitrary = bgr.at<cv::Vec3b>(0,2);
+				CHECK(std::abs(int(arbitrary[2]) - 96) < 2);
+				CHECK(std::abs(int(arbitrary[1]) - 75) < 2);
+				CHECK(std::abs(int(arbitrary[0]) - 87) < 2);
+
+				auto && white = bgr.at<cv::Vec3b>(1,0);
+				CHECK(std::abs(int(white[2]) - 255) < 2);
+				CHECK(std::abs(int(white[1]) - 255) < 2);
+				CHECK(std::abs(int(white[0]) - 255) < 2);
+
+			}
+		}
+	}
+
+}
+
+}
+}
+}


### PR DESCRIPTION
 - Write own conversions based on SP3000 routines
 - Update parameters to match SP3000 tolerances
 - Replace OpenCV conversions throughout with our own
 - Tests for our own implementation, using values generated from SP3000
   routines

Fixes #10